### PR TITLE
Merge nstripes and freebytes from 2024-02

### DIFF
--- a/tools/freebytes.py
+++ b/tools/freebytes.py
@@ -1,51 +1,28 @@
 #!/usr/bin/env python3
 """
-freebytes.py
-Counts free bytes in a ROM produced by ld65
+This program counts how many free bytes are in the whole ROM.
 
-Copyright 2023 Retrotainment Games LLC
+Some data has to be in named memory areas, such as code and small
+lookup tables used by code.  The last 16K of the ROM is an especially
+important memory area called HOME, as it is always visible no matter
+which banks are switched in.  Bulk data can be in a large contiguous
+area that the HH86 and FQ linker scripts call LINEAR.  Creating a
+named memory area takes 8 to 16 KiB away from LINEAR, but anything in
+LINEAR can be redistributed to free space in a named memory area.
+Near the end of HH86 development, for example, sprite cels were moved
+to other memory area.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
-----
-
-A program for Nintendo Entertainment System (NES) is divided into
-memory areas, also called banks.  A support circuit called a mapper
-causes some of these memory areas to be visible to the CPU at any
-moment.  Some data has to be in named memory areas, such as code and
-small lookup tables used by code.  The last 16 KiB of the ROM is an
-especially important memory area called HOME, as it is always visible
-no matter which banks are switched in.  Bulk data can be in a large
-contiguous area that Retrotainment's linker scripts call LINEAR.
-Creating a named memory area takes 8 to 16 KiB away from LINEAR, but
-most data in LINEAR can be redistributed to free space in a named
-memory area.  Late in a game's development, for example, sprite cels
-are often moved back and forth between LINEAR and other areas.
-
-This program uses the linker script and the linker's map output to
-estimate the free space in the whole ROM, even if things were to be
-moved in or out of LINEAR or HOME.
+The ROM's level select screen shows estimates of free space in LINEAR
+and HOME.  This program uses the linker script and the linker's map
+output to estimate the free space in the whole ROM, even if things
+were to be moved in or out of LINEAR or HOME.
 
 1. Read memory area and segment assignments from linker script
 2. Read segment sizes from map.txt
 3. Calculate how much of each memory area is occupied
 
 """
-import os, sys, re
-
-PROGDIR = os.path.dirname(sys.argv[0])
-linkscriptname = os.path.join(PROGDIR, "..", "mmc3_4mbit_packed.cfg")
-mapoutputname = os.path.join(PROGDIR, "..", "map.txt")
+import os, sys, argparse, re
 
 # Loading linker script #############################################
 
@@ -98,9 +75,18 @@ def ld65_map_get_sections(filename):
         for s in sections
     }
 
-def main():
-    lscontents, memstartsize, segtomem = ld65_load_linker_script(linkscriptname)
-    mapsections = ld65_map_get_sections(mapoutputname)
+def parse_argv(argv):
+    p = argparse.ArgumentParser(description="Calculates free space by bank in a cc65 project.")
+    p.add_argument("-C", "--config",
+                   help="path to ld65 config file")
+    p.add_argument("-m", "--mapfile",
+                   help="path to map file written by ld65")
+    return p.parse_args(argv[1:])
+
+def main(argv=None):
+    args = parse_argv(argv or sys.argv)
+    lscontents, memstartsize, segtomem = ld65_load_linker_script(args.config)
+    mapsections = ld65_map_get_sections(args.mapfile)
     seglist = [
         line.split() for line in mapsections["name start end size align"] if line
     ]
@@ -141,4 +127,9 @@ def main():
           % (poolsize - poolused))
 
 if __name__=='__main__':
-    main()
+    if "idlelib" in sys.modules:
+        main("""
+./freebytes.py -C ../bnrom1mbit.cfg -m ../map.txt
+""".split())
+    else:
+        main()

--- a/tools/freebytes.py
+++ b/tools/freebytes.py
@@ -1,21 +1,33 @@
 #!/usr/bin/env python3
 """
-This program counts how many free bytes are in the whole ROM.
-
-Some data has to be in named memory areas, such as code and small
-lookup tables used by code.  The last 16K of the ROM is an especially
-important memory area called HOME, as it is always visible no matter
-which banks are switched in.  Bulk data can be in a large contiguous
-area that the HH86 and FQ linker scripts call LINEAR.  Creating a
-named memory area takes 8 to 16 KiB away from LINEAR, but anything in
-LINEAR can be redistributed to free space in a named memory area.
-Near the end of HH86 development, for example, sprite cels were moved
-to other memory area.
-
-The ROM's level select screen shows estimates of free space in LINEAR
-and HOME.  This program uses the linker script and the linker's map
-output to estimate the free space in the whole ROM, even if things
-were to be moved in or out of LINEAR or HOME.
+freebytes.py
+Counts free bytes in a ROM produced by ld65
+Copyright 2023 Retrotainment Games LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+----
+A program for Nintendo Entertainment System (NES) is divided into
+memory areas, also called banks.  A support circuit called a mapper
+causes some of these memory areas to be visible to the CPU at any
+moment.  Some data has to be in named memory areas, such as code and
+small lookup tables used by code.  The last 16 KiB of the ROM is an
+especially important memory area called HOME, as it is always visible
+no matter which banks are switched in.  Bulk data can be in a large
+contiguous area that Retrotainment's linker scripts call LINEAR.
+Creating a named memory area takes 8 to 16 KiB away from LINEAR, but
+most data in LINEAR can be redistributed to free space in a named
+memory area.  Late in a game's development, for example, sprite cels
+are often moved back and forth between LINEAR and other areas.
+This program uses the linker script and the linker's map output to
+estimate the free space in the whole ROM, even if things were to be
+moved in or out of LINEAR or HOME.
 
 1. Read memory area and segment assignments from linker script
 2. Read segment sizes from map.txt

--- a/tools/freebytes.py
+++ b/tools/freebytes.py
@@ -2,17 +2,23 @@
 """
 freebytes.py
 Counts free bytes in a ROM produced by ld65
+
 Copyright 2023 Retrotainment Games LLC
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
 ----
+
 A program for Nintendo Entertainment System (NES) is divided into
 memory areas, also called banks.  A support circuit called a mapper
 causes some of these memory areas to be visible to the CPU at any
@@ -25,6 +31,7 @@ Creating a named memory area takes 8 to 16 KiB away from LINEAR, but
 most data in LINEAR can be redistributed to free space in a named
 memory area.  Late in a game's development, for example, sprite cels
 are often moved back and forth between LINEAR and other areas.
+
 This program uses the linker script and the linker's map output to
 estimate the free space in the whole ROM, even if things were to be
 moved in or out of LINEAR or HOME.


### PR DESCRIPTION
ongoing development at Retrotainment led to these improvements

- nstripes.py: add an option for starting tile ID of extracted CHR data
- freebytes.py: don't hardcode linker script and output names
